### PR TITLE
Update the agent and add mk-job

### DIFF
--- a/modules/check_mk_agent.nix
+++ b/modules/check_mk_agent.nix
@@ -86,23 +86,6 @@ in
       };
     };
 
-    systemd.services."cmk-agent-ctl-daemon" = {
-      # https://github.com/tribe29/checkmk/blob/2.1.0/agents/scripts/super-server/0_systemd/cmk-agent-ctl-daemon.service
-      description = "Checkmk agent controller daemon";
-
-      requires = [ "check_mk_agent.socket" ];
-      after = [ "network-online.target" ];
-      wants = [ "network-online.target" ];
-      wantedBy = [ "multi-user.target" ];
-
-      serviceConfig = {
-        ExecStart = "${cfg.package}/bin/cmk-agent-ctl daemon";
-        Type = "simple";
-        User = "root"; # cmk-agent
-        Restart = "on-failure";
-      };
-    };
-
     systemd.sockets.check_mk_agent = {
       # https://github.com/tribe29/checkmk/blob/2.1.0/agents/scripts/super-server/0_systemd/check-mk-agent.socket.fallback
       description = "Checkmk Agent Socket";

--- a/modules/check_mk_agent.nix
+++ b/modules/check_mk_agent.nix
@@ -52,24 +52,60 @@ in
     };
 
     systemd.services."check_mk_agent@" = {
-      # https://github.com/tribe29/checkmk/blob/v2.0.0p1/agents/cfg_examples/systemd/check_mk@.service
-      description = "checkmk agent";
+      # https://github.com/tribe29/checkmk/blob/2.1.0/agents/scripts/super-server/0_systemd/check-mk-agent%40.service
+      description = "Checkmk agent";
 
       requires = [ "check_mk_agent.socket" ];
+      environment.MK_RUN_ASYNC_PARTS = "false";
+      environment.MK_READ_REMOTE = "true";
 
       serviceConfig = {
         ExecStart = "-${cfg.package}/bin/check_mk_agent";
-        Type = "forking";
+        Type = "simple";
         User = "root";
-        Group = "root";
         StandardInput = "socket";
         StateDirectory = "check_mk_agent";  # creates /var/lib/check_mk_agent
       };
     };
 
+    systemd.services."check-mk-agent-async" = {
+      # https://github.com/tribe29/checkmk/blob/2.1.0/agents/scripts/super-server/0_systemd/check-mk-agent-async.service
+      description = "Checkmk agent - Asynchronous background tasks";
+
+      requires = [ "check_mk_agent.socket" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      environment.MK_RUN_SYNC_PARTS = "false";
+      environment.MK_LOOP_INTERVAL = "60";
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/check_mk_agent";
+        Type = "simple";
+        User = "root";
+      };
+    };
+
+    systemd.services."cmk-agent-ctl-daemon" = {
+      # https://github.com/tribe29/checkmk/blob/2.1.0/agents/scripts/super-server/0_systemd/cmk-agent-ctl-daemon.service
+      description = "Checkmk agent controller daemon";
+
+      requires = [ "check_mk_agent.socket" ];
+      after = [ "network-online.target" ];
+      wants = [ "network-online.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      serviceConfig = {
+        ExecStart = "${cfg.package}/bin/cmk-agent-ctl daemon";
+        Type = "simple";
+        User = "root"; # cmk-agent
+        Restart = "on-failure";
+      };
+    };
+
     systemd.sockets.check_mk_agent = {
-      # https://github.com/tribe29/checkmk/blob/v2.0.0p1/agents/cfg_examples/systemd/check_mk.socket
-      description = "checkmk agent socket";
+      # https://github.com/tribe29/checkmk/blob/2.1.0/agents/scripts/super-server/0_systemd/check-mk-agent.socket.fallback
+      description = "Checkmk Agent Socket";
       partOf = [ "check_mk_agent@.service" ];
       wantedBy = [ "sockets.target" ];
 

--- a/modules/check_mk_agent.nix
+++ b/modules/check_mk_agent.nix
@@ -43,6 +43,15 @@ in
           Whether to open the port in the firewall for the agent.
         '';
       };
+
+      user = mkOption {
+        type = with types; nullOr str;
+        default = "root";
+        description = ''
+          The agent user
+        '';
+        example = "s-quaivesaas";
+      };
     };
   };
 
@@ -62,7 +71,7 @@ in
       serviceConfig = {
         ExecStart = "-${cfg.package}/bin/check_mk_agent";
         Type = "simple";
-        User = "root";
+        User = cfg.user;
         StandardInput = "socket";
         StateDirectory = "check_mk_agent";  # creates /var/lib/check_mk_agent
       };
@@ -82,7 +91,7 @@ in
       serviceConfig = {
         ExecStart = "${cfg.package}/bin/check_mk_agent";
         Type = "simple";
-        User = "root";
+        User = cfg.user;
       };
     };
 

--- a/pkgs/check_mk_agent/default.nix
+++ b/pkgs/check_mk_agent/default.nix
@@ -80,6 +80,11 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
+    install -m755 -D agents/mk-job "$out/bin/mk-job"
+    wrapProgram "$out/bin/mk-job" \
+      --prefix PATH : ${pkgs.lib.makeBinPath deps} \
+      --set-default MK_LIBDIR $out/usr/lib/mk-job \
+      --set-default MK_CONFDIR $out/etc/mk-job
     install -m755 -D agents/check_mk_agent.linux "$out/bin/check_mk_agent"
     wrapProgram "$out/bin/check_mk_agent" \
       --prefix PATH : ${lib.makeBinPath deps} \

--- a/pkgs/check_mk_agent/default.nix
+++ b/pkgs/check_mk_agent/default.nix
@@ -85,12 +85,9 @@ stdenv.mkDerivation rec {
     install -m755 -D agents/mk-job "$out/bin/mk-job"
     wrapProgram "$out/bin/mk-job" \
       --prefix PATH : ${pkgs.lib.makeBinPath deps} \
-      --set-default MK_LIBDIR $out/usr/lib/mk-job \
-      --set-default MK_CONFDIR $out/etc/mk-job
     install -m755 -D agents/check_mk_agent.linux "$out/bin/check_mk_agent"
     wrapProgram "$out/bin/check_mk_agent" \
       --prefix PATH : ${lib.makeBinPath deps} \
-      --set-default MK_LIBDIR $out/usr/lib/check_mk_agent \
       --set-default MK_CONFDIR $out/etc/check_mk_agent
   '' + lib.concatStringsSep "\n" (map pluginInstallPhase pluginsToInstall) + ''
     patchShebangs $out/bin/

--- a/pkgs/check_mk_agent/default.nix
+++ b/pkgs/check_mk_agent/default.nix
@@ -20,6 +20,7 @@ let
     gnused
     gawk
     iproute
+    time
   ];
   python = pkgs.python38;
   pythonPackages = pkgs.python38Packages;
@@ -80,6 +81,7 @@ stdenv.mkDerivation rec {
   '';
 
   installPhase = ''
+    sed -i "s#/usr/bin/time#${pkgs.time}/bin/time#g" agents/mk-job
     install -m755 -D agents/mk-job "$out/bin/mk-job"
     wrapProgram "$out/bin/mk-job" \
       --prefix PATH : ${pkgs.lib.makeBinPath deps} \

--- a/pkgs/check_mk_agent/default.nix
+++ b/pkgs/check_mk_agent/default.nix
@@ -84,7 +84,7 @@ stdenv.mkDerivation rec {
     sed -i "s#/usr/bin/time#${pkgs.time}/bin/time#g" agents/mk-job
     install -m755 -D agents/mk-job "$out/bin/mk-job"
     wrapProgram "$out/bin/mk-job" \
-      --prefix PATH : ${pkgs.lib.makeBinPath deps} \
+      --prefix PATH : ${pkgs.lib.makeBinPath deps}
     install -m755 -D agents/check_mk_agent.linux "$out/bin/check_mk_agent"
     wrapProgram "$out/bin/check_mk_agent" \
       --prefix PATH : ${lib.makeBinPath deps} \

--- a/pkgs/check_mk_agent/default.nix
+++ b/pkgs/check_mk_agent/default.nix
@@ -64,13 +64,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "check_mk_agent";
-  version = "v2.0.0p16";
+  version = "v2.1.0p6";
 
   src = fetchFromGitHub {
     owner = "tribe29";
     repo = "checkmk";
     rev = version;
-    sha256 = "0xxw47ddr81g558qqal6dn2774pfzxr62lr2r6cj06ifgb8chslv";
+    sha256 = "1kzik7jpsilsidxvfz8vyaqr6lq0fg9794nmdczg4ypfmanfjrhm";
   };
 
   buildInputs = [ pkgs.makeWrapper python.pkgs.wrapPython ];

--- a/pkgs/check_mk_agent/default.nix
+++ b/pkgs/check_mk_agent/default.nix
@@ -88,6 +88,7 @@ stdenv.mkDerivation rec {
     install -m755 -D agents/check_mk_agent.linux "$out/bin/check_mk_agent"
     wrapProgram "$out/bin/check_mk_agent" \
       --prefix PATH : ${lib.makeBinPath deps} \
+      --set-default MK_LIBDIR $out/usr/lib/check_mk_agent \
       --set-default MK_CONFDIR $out/etc/check_mk_agent
   '' + lib.concatStringsSep "\n" (map pluginInstallPhase pluginsToInstall) + ''
     patchShebangs $out/bin/


### PR DESCRIPTION
Thanks for sharing your overlay, @BenediktSeidl. I've extended it a little to add support for mk-job, for monitoring cron jobs. I noticed that if I ran the agent as root, it wasn't picking up the data from mk-job for users, so I added the option to specify a user to run it as. This is really a hack, so it may not be interesting to you, but I thought I'd open a PR anyway in case you notice something useful. Cheers!